### PR TITLE
fix: create project, missing field

### DIFF
--- a/src/models/Project.js
+++ b/src/models/Project.js
@@ -19,6 +19,9 @@ export const Project = sequelize.define(
     description: {
       type: DataTypes.STRING,
     },
+    deliverydate: {
+      type: DataTypes.DATE,
+    }
   },
   {
     timestamps: false,


### PR DESCRIPTION
It was giving error while creating project, you forgot to add `deliveryDate` field while creating project. It fixes.